### PR TITLE
nodectl link and command update

### DIFF
--- a/validate/automated/nodectl.md
+++ b/validate/automated/nodectl.md
@@ -17,7 +17,7 @@ import DocsCards from '@components/global/DocsCards';
 
 ## What is nodectl
 
-nodectl pronounced node "c" "t" "l", node-kuttle, or node control.
+nodectl pronounced node "c" "t" "l", node-cuttle, or node control.
 
 The purpose of this utility is to make things easier on you.  
 

--- a/validate/automated/nodectlCommands.md
+++ b/validate/automated/nodectlCommands.md
@@ -1351,7 +1351,7 @@ You should use an unused port between `1024` and `65535`.
 
 | [switch](#what-is-a-switch-and-parameter) | parameters | Description | Is [Switch](#what-is-a-switch-and-parameter) Required or Optional |
 | :---: | :---: | :--- | :----: |
-| -p | `<port number>` | Which port number would you like to change your SSH port for use? | **required** |
+| --port | `<port number>` | Which port number would you like to change your SSH port for use? | **required** |
 
 > #### Examples
 - Help file
@@ -1360,7 +1360,7 @@ sudo nodectl change_ssh_port help
 ```
 - Change SSH TCP port to port `4242`
 ```
-sudo nodectl change_ssh_port -p 4242
+sudo nodectl change_ssh_port --port 4242
 ```
 
 

--- a/validate/index.md
+++ b/validate/index.md
@@ -19,15 +19,15 @@ import DocsCards from '@components/global/DocsCards';
 In this tutorial, Node Operators will learn how to build and manage a validator node.
 
 <DocsCards>
-  <DocsCard header="Build a VPS" href="validator/getting-started" img="/img/validator_nodes/cloud.png">
+  <DocsCard header="Build a VPS" href="/validate/validator/getting-started" img="/img/validator_nodes/cloud.png">
     <p>Setup a Virtual Private Server (VPS) in the cloud including SSH keys; to install your Constellation Node.</p>
   </DocsCard>
 
-  <DocsCard header="NODECTL User Guide" href="automated/nodectl" img="/img/validator_nodes/nodes_logo.jpg">
+  <DocsCard header="NODECTL User Guide" href="/validate/automated/nodectl" img="/img/validator_nodes/nodes_logo.jpg">
     <p>Turn your VPS into a Constellation Node using Constellation Network's <b>nodectl</b> utility.</p>
   </DocsCard>
 
-  <DocsCard header="Manual Installation" href="manual/manual-install-getting-started" img="/img/validator_nodes/hard_hat.png">
+  <DocsCard header="Manual Installation" href="/validate/manual/manual-install-getting-started" img="/img/validator_nodes/hard_hat.png">
     <p>ADVANCED: <b>Manually</b> setup a Node from a clean Debian installation.</p>
   </DocsCard>
 </DocsCards>


### PR DESCRIPTION
- Fixes invalid links on validator intro page
- Update to the `change_ssh_port` command (release `v2.8.0`)