### PR TITLE
simplify instructions

### DIFF
--- a/validate/manual/binaries.md
+++ b/validate/manual/binaries.md
@@ -47,10 +47,10 @@ sudo wget https://github.com/Constellation-Labs/tessellation/releases/latest/dow
 sudo wget https://github.com/Constellation-Labs/tessellation/releases/latest/download/cl-node.jar -P /var/tessellation
 sudo wget https://github.com/Constellation-Labs/tessellation/releases/latest/download/cl-dag-l1.jar -P /var/tessellation
 sudo wget https://github.com/Constellation-Labs/tessellation/releases/latest/download/cl-wallet.jar -P /var/tessellation
-sudo wget https://github.com/Constellation-Labs/tessellation/releases/latest/download/mainnet-seedlist -P /var/tessellation
+sudo wget https://github.com/Constellation-Labs/tessellation/releases/latest/download/mainnet-seedlist -O /var/tessellation/seed-list -o /dev/null
 
+# set executable flag
 sudo chmod +x /var/tessellation/*.jar
-sudo chmod +x /var/tessellation/cl-wallet.jar -O /var/tessellation/seed-list -o /dev/null
 ```
 
 Let's verify that our files are in place. Depending on your terminal application, the files should appear in GREEN. Make sure they are executable:  `-rwxr-xr-x`

--- a/validate/manual/binaries.md
+++ b/validate/manual/binaries.md
@@ -14,7 +14,7 @@ hide_table_of_contents: false
 We are now ready to install `Tessellation` on our VPS instance which will turn it into a Constellation Tessellation validator node!
 ## Instructions
 
-### Log into your node
+### Log into your VPS
 
 From your **local system**, log into your **cloud instance's** terminal as **nodeadmin** using your Apple terminal, Window's PuTTY, or your terminal application of choice.
 
@@ -22,54 +22,35 @@ From your **local system**, log into your **cloud instance's** terminal as **nod
 You can remind yourself how to access your VPS here for [Macintosh](/validate/resources/accessMac) or [Windows](/validate/resources/accessWin).
 :::
 
-### Update node
+### Update Package Manager
 
-Bring our Node up to date
+Bring our VPS OS Package Manager up to date
 
 ```
 sudo apt -y update && sudo apt -y upgrade
 ```
 
-You will be prompted for your nodeadmin password.
-:::warning
-Your screen will not react and your password will not show as you type.  
-**Reminder**: `[...]` in the output command examples means that there is a bunch of output that has been redacted to eliminate confusion. 
-:::
+You will be prompted for your nodeadmin password (your screen will not react and your password will not show as you type).
+
 ```
 [sudo] password for nodeadmin:
-[...]
 ```
 
-### Download packages
+### Download Packages
 
-We are ready to download the Tessellation packages that will be executed on your VPS to turn it into a **Node**. We can now pull down the latest release from Constellation Network's repository.
+We are ready to download the Tessellation packages that will be executed on your VPS to turn it into a **Constellation Network Node**.
 
-:::danger VERY IMPORTANT
-When downloading Tessellation...
+Copy and execute the commands below into your terminal window (one by one, or all together):
 
-MAKE SURE YOU USE THE **CORRECT** VERSION!  
-Installing an older or incorrect version could lead to unexpected results.
-:::
+```sh
+sudo wget https://github.com/Constellation-Labs/tessellation/releases/latest/download/cl-keytool.jar -P /var/tessellation
+sudo wget https://github.com/Constellation-Labs/tessellation/releases/latest/download/cl-node.jar -P /var/tessellation
+sudo wget https://github.com/Constellation-Labs/tessellation/releases/latest/download/cl-dag-l1.jar -P /var/tessellation
+sudo wget https://github.com/Constellation-Labs/tessellation/releases/latest/download/cl-wallet.jar -P /var/tessellation
+sudo wget https://github.com/Constellation-Labs/tessellation/releases/latest/download/mainnet-seedlist -P /var/tessellation
 
-Download the **cl-keytool.jar** JAR file.
-```
-sudo wget https://github.com/Constellation-Labs/tessellation/releases/download/v1.0.1/cl-keytool.jar -P /var/tessellation; sudo chmod +x /var/tessellation/cl-keytool.jar
-```
-Download the **cl-node.jar** JAR file.
-```
-sudo wget https://github.com/Constellation-Labs/tessellation/releases/download/v1.0.1/cl-node.jar -P /var/tessellation; sudo chmod +x /var/tessellation/cl-node.jar
-```
-Download the **cl-dag-l1.jar** JAR file.
-```
-sudo wget https://github.com/Constellation-Labs/tessellation/releases/download/v1.0.1/cl-dag-l1.jar -P /var/tessellation; sudo chmod +x /var/tessellation/cl-dag-l1.jar
-```
-Download the **cl-wallet.jar** JAR file.
-```
-sudo wget https://github.com/Constellation-Labs/tessellation/releases/download/v1.0.1/cl-wallet.jar -P /var/tessellation; sudo chmod +x /var/tessellation/cl-wallet.jar
-```
-Download the **seed list file** that contains the Node IDs with permissions to JOIN the network.
-```
-sudo wget https://github.com/Constellation-Labs/tessellation/releases/download/v1.0.1/mainnet-seedlist -P /var/tessellation; sudo chmod +x /var/tessellation/cl-wallet.jar -O /var/tessellation/seed-list -o /dev/null
+sudo chmod +x /var/tessellation/*.jar
+sudo chmod +x /var/tessellation/cl-wallet.jar -O /var/tessellation/seed-list -o /dev/null
 ```
 
 Let's verify that our files are in place. Depending on your terminal application, the files should appear in GREEN. Make sure they are executable:  `-rwxr-xr-x`
@@ -78,7 +59,7 @@ Let's verify that our files are in place. Depending on your terminal application
 ls -l /var/tessellation
 ```
 
-Output should look similar (*but not exactly*) to the 👇 .
+Output should look similar (*but not exactly*) to this:
 
 ```
 total 140568
@@ -88,6 +69,7 @@ total 140568
 -rwxr-xr-x 1 root root 75646006 Jul 10 16:24 cl-wallet.jar
 -rwxr-xr-x 1 root root    29928 Jul 10 16:24 seed-list
 ```
+
 That is all we need.
 
 We are ready to **create** or **transfer** our **`P12`** file.


### PR DESCRIPTION
sample re #57, needs further simplification

Final result could be as little as:

```sh
# get the setup script
wget github[...]/latest/tess-node-setup.sh

# make it executable
chmod +x tess-node-setup.sh

# (OPTIONAL): review the setup script
cat tess-node-setup.sh

# execute the setup script
./tess-node-setup.sh
```

Please remember that a professional/production grade setup would be a one-liner (works fine for both, pro-devs and casual users):

`sudo apt install tessellation-node`