### PR TITLE
Update 03-generating-metagraph-jars.md

### DIFF
--- a/sdk/guides/deploy-a-metagraph/base-instance/03-generating-metagraph-jars.md
+++ b/sdk/guides/deploy-a-metagraph/base-instance/03-generating-metagraph-jars.md
@@ -102,7 +102,7 @@ cd ..
 cd ..
 mv your_project_directory/modules/l0/target/scala-2.13/my-project-currency-l0-assembly-0.1.0-SNAPSHOT.jar metagraph-l0/metagraph-l0.jar
 mv your_project_directory/modules/l1/target/scala-2.13/my-project-currency-l1-assembly-0.1.0-SNAPSHOT.jar currency-l1/currency-l1.jar
-mv your_project_directory/modules/data_l1/target/scala-2.13/my-project-data-l1-assembly-0.1.0-SNAPSHOT.jar data-l1/data-l1.jar
+mv your_project_directory/modules/data_l1/target/scala-2.13/my-project-data_l1-assembly-0.1.0-SNAPSHOT.jar data-l1/data-l1.jar
 ```
 
 :::info


### PR DESCRIPTION
I think I found a typo on the BaseImage instructions...

This...
`mv your_project_directory/modules/data_l1/target/scala-2.13/my-project-data-l1-assembly-0.1.0-SNAPSHOT.jar data-l1/data-l1.jar`

Should be...
`mv your_project_directory/modules/data_l1/target/scala-2.13/my-project-data_l1-assembly-0.1.0-SNAPSHOT.jar data-l1/data-l1.jar`

`data-l1-assembly` should be: `data_l1-assembly` (with the underscore).

I noticed at the completion of everything the file was named with the underscore and not the dash.